### PR TITLE
ONEcode python interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ all: $(LIB) $(PROGS)
 clean:
 	$(RM) *.o ONEstat ONEview $(LIB) ZZ* TEST/ZZ* ONEcpptest.cpp ONEcpptest
 	$(RM) -r *.dSYM
+	$(RM) ONEcode*.so
 
 install:
 	cp $(PROGS) $(DEST_DIR)
@@ -56,5 +57,18 @@ ONEcpptest: ONEcpptest.cpp ONElib.o
 
 cpptest: ONEcpptest
 	./ONEcpptest TEST/ZZ-small.1seq
+
+### Python bindings
+
+python: $(LIB)
+	$(CCPP) -O3 -Wall -shared -std=c++11 -fPIC -undefined dynamic_lookup \
+		$$(python3 -m pybind11 --includes) pyONElib.cpp \
+		-o ONEcode$$(python3-config --extension-suffix) ONElib.o
+
+python-test: python
+	python3 -c "import ONEcode; print('ONEcode module loaded successfully')"
+
+python-install: python
+	pip3 install -e .
 
 ### end of file

--- a/Python-interface.md
+++ b/Python-interface.md
@@ -2,17 +2,17 @@
 
 ## Installation and compilation
 
-To set up the Python bindings for the C++ interface, first install [pybind11](https://github.com/pybind/pybind11). The following was done using the [conda installion](https://pybind11.readthedocs.io/en/latest/installing.html#include-with-conda-forge).
+The ONEcode Python bindings provide a complete Python interface to the ONEcode library using pybind11.
 
-After installing, first compile the library:
-```
+```bash
+# First compile the ONElib library
 make
+
+# Then compile the Python binding
+make python
 ```
-Then compile the Python binding with:
-```
-g++ -O3 -Wall -shared -std=c++11 -fPIC $(python3 -m pybind11 --includes) pyONElib.cpp -o ONEcode$(python3-config --extension-suffix) ONElib.o
-```
-This should result in a `.so` file.
+
+This creates a `.so` file.
 
 ## Usage
 
@@ -51,5 +51,77 @@ while onefile.readLine():
         print("Sequence length", onefile.length())
 ```
 
-## Further work
-* Use `setuptools` to compile and install, so the library will be available system-wide and publishable to `pip`.
+## API Reference
+
+### ONEschema Class
+
+- `ONEschema(schema_text: str)`: Create a schema from schema text
+
+### ONEfile Class
+
+#### Constructors
+- `ONEfile(path: str)`: Open existing file for reading (1 thread)
+- `ONEfile(path: str, nthreads: int)`: Open existing file with multiple threads
+- `ONEfile(path: str, mode: str, schema: ONEschema, type: str, nthreads: int)`: Full constructor
+- `ONEfile(path: str, mode: str, source: ONEfile, nthreads: int)`: Create from another file
+
+#### Reading Methods
+- `readLine() -> char`: Read next line, returns line type
+- `lineType() -> char`: Get current line type
+- `lineNumber() -> int`: Get current line number
+- `length() -> int`: Get length of current list
+- `getInt(field: int) -> int`: Get integer field value
+- `getReal(field: int) -> float`: Get real field value
+- `getChar(field: int) -> char`: Get character field value
+- `getIntList() -> list[int]`: Get integer list
+- `getRealList() -> list[float]`: Get real list
+- `getString() -> str`: Get string from list
+- `getStringList() -> list[str]`: Get string list
+- `getDNAchar() -> str`: Get DNA as character string
+- `getDNA2bit() -> bytes`: Get DNA in 2-bit compressed format
+- `getComment() -> str`: Read comment line
+
+#### Writing Methods
+- `setInt(field: int, value: int)`: Set integer field
+- `setReal(field: int, value: float)`: Set real field
+- `setChar(field: int, value: char)`: Set character field
+- `writeLine(lineType: str)`: Write line with no list
+- `writeLine(lineType: str, s: str)`: Write line with string
+- `writeLine(lineType: str, slist: list[str])`: Write line with string list
+- `writeLineIntList(lineType: str, data: list[int])`: Write line with integer list
+- `writeLineRealList(lineType: str, data: list[float])`: Write line with real list
+- `writeLineDNA2bit(lineType: str, dnaLen: int, dnaBuf: bytes)`: Write DNA in 2-bit format
+- `writeComment(comment: str)`: Write comment line
+
+#### Metadata Methods
+- `givenCount(lineType: str) -> int`: Get given count for line type
+- `givenMax(lineType: str) -> int`: Get given max for line type
+- `givenTotal(lineType: str) -> int`: Get given total for line type
+- `currentCount(lineType: str) -> int`: Get current count for line type
+- `currentMax(lineType: str) -> int`: Get current max for line type
+- `currentTotal(lineType: str) -> int`: Get current total for line type
+- `count(lineType: str) -> int`: Get count (write mode uses accum, read mode uses given)
+- `max(lineType: str) -> int`: Get max value
+- `total(lineType: str) -> int`: Get total value
+- `fileName() -> str`: Get file name
+
+#### Provenance Methods
+- `addProvenance(prog: str, version: str, commandLine: str) -> bool`: Add provenance
+- `inheritProvenance(source: ONEfile) -> bool`: Inherit provenance from another file
+- `addReference(filename: str, count: int) -> bool`: Add reference to another file
+- `inheritReference(source: ONEfile) -> bool`: Inherit reference from another file
+
+#### Navigation Methods
+- `gotoObject(lineType: str, index: int) -> bool`: Jump to specific object
+
+#### Schema Methods
+- `checkSchemaText(text: str) -> bool`: Check if file matches schema text
+- `checkSchema(schema: ONEschema, isRequired: bool) -> bool`: Check against schema object
+
+## Notes
+
+- All methods that take a `lineType` parameter expect a single character string (e.g., `'S'`, `'I'`)
+- The module handles conversion between Python types and C++ types automatically
+- Files are automatically closed when the ONEfile object is destroyed
+- For writing files, mode `"w"` creates ASCII format, `"wb"` creates binary format
+- Thread count parameter allows parallel decompression when reading binary files

--- a/pyONElib.cpp
+++ b/pyONElib.cpp
@@ -2,6 +2,7 @@
 #include "ONElib.hpp"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -15,7 +16,10 @@ PYBIND11_MODULE(ONEcode, m) {
         .def(py::init<const std::string &, const std::string &, const ONEschema &, const std::string &, int>())
         .def(py::init<const std::string &, const std::string &, ONEfile &, int>())
         .def("checkSchemaText", &ONEfile::checkSchemaText)
-        .def("readLine", &ONEfile::readLine)
+        .def("readLine", [](ONEfile &self) -> bool {
+            char result = self.readLine();
+            return result != 0;  // Return true if we read a line, false at EOF
+        })
         .def("length", &ONEfile::listLength)
         .def("getInt", &ONEfile::getInt)
         .def("setInt", &ONEfile::setInt)
@@ -26,7 +30,14 @@ PYBIND11_MODULE(ONEcode, m) {
         .def("getIntList", &ONEfile::getIntList)
         .def("getRealList", &ONEfile::getRealList)
         .def("getDNAchar", &ONEfile::getDNAchar)
-        .def("getDNA2bit", &ONEfile::getDNA2bit)
+        // getDNA2bit returns 2-bit compressed DNA as Python bytes
+        // 4 bases per byte, so byte_length = (num_bases + 3) / 4
+        .def("getDNA2bit", [](ONEfile &self) -> py::bytes {
+            uint8_t *data = self.getDNA2bit();
+            int64_t num_bases = self.listLength();
+            size_t byte_length = (num_bases + 3) / 4;
+            return py::bytes(reinterpret_cast<char*>(data), byte_length);
+        })
         .def("getString", &ONEfile::getString)
         .def("getStringList", &ONEfile::getStringList)
         .def("getComment", &ONEfile::getComment)
@@ -34,47 +45,130 @@ PYBIND11_MODULE(ONEcode, m) {
         .def("lineType", &ONEfile::lineType)
         .def("lineNumber", &ONEfile::lineNumber)
         
-        // Updated function bindings to handle string-to-char conversion
+        // Metadata access methods
         .def("givenCount", [](ONEfile &self, const std::string &lineType) {
             if (lineType.length() != 1) {
                 throw std::invalid_argument("lineType must be a single character");
             }
-            return self.givenCount(static_cast<unsigned char>(lineType[0]));
+            return self.count(lineType[0]);  // For read files, count() returns given.count
         })
-        
+
         .def("givenMax", [](ONEfile &self, const std::string &lineType) {
             if (lineType.length() != 1) {
                 throw std::invalid_argument("lineType must be a single character");
             }
-            return self.givenMax(static_cast<unsigned char>(lineType[0]));
+            return self.max(lineType[0]);  // For read files, max() returns given.max
         })
 
         .def("givenTotal", [](ONEfile &self, const std::string &lineType) {
             if (lineType.length() != 1) {
                 throw std::invalid_argument("lineType must be a single character");
             }
-            return self.givenTotal(static_cast<unsigned char>(lineType[0]));
+            return self.total(lineType[0]);  // For read files, total() returns given.total
         })
 
         .def("currentCount", [](ONEfile &self, const std::string &lineType) {
             if (lineType.length() != 1) {
                 throw std::invalid_argument("lineType must be a single character");
             }
-            return self.currentCount(static_cast<unsigned char>(lineType[0]));
+            // For write files, count() returns accum.count (current)
+            return self.count(lineType[0]);
         })
 
         .def("currentMax", [](ONEfile &self, const std::string &lineType) {
             if (lineType.length() != 1) {
                 throw std::invalid_argument("lineType must be a single character");
             }
-            return self.currentMax(static_cast<unsigned char>(lineType[0]));
+            return self.max(lineType[0]);
         })
 
         .def("currentTotal", [](ONEfile &self, const std::string &lineType) {
             if (lineType.length() != 1) {
                 throw std::invalid_argument("lineType must be a single character");
             }
-            return self.currentTotal(static_cast<unsigned char>(lineType[0]));
-        });
+            return self.total(lineType[0]);
+        })
+
+        // Write methods
+        .def("setInt", &ONEfile::setInt)
+        .def("setReal", &ONEfile::setReal)
+        .def("setChar", &ONEfile::setChar)
+
+        .def("writeLine", [](ONEfile &self, const std::string &lineType) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            self.writeLine(lineType[0]);
+        })
+
+        .def("writeLine", [](ONEfile &self, const std::string &lineType, const std::string &s) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            self.writeLine(lineType[0], s);
+        })
+
+        .def("writeLine", [](ONEfile &self, const std::string &lineType, const std::vector<std::string> &slist) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            self.writeLine(lineType[0], slist);
+        })
+
+        .def("writeLineIntList", [](ONEfile &self, const std::string &lineType, const std::vector<int64_t> &data) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            self.writeLine(lineType[0], data.size(), (void*)data.data());
+        })
+
+        .def("writeLineRealList", [](ONEfile &self, const std::string &lineType, const std::vector<double> &data) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            self.writeLine(lineType[0], data.size(), (void*)data.data());
+        })
+
+        .def("writeLineDNA2bit", [](ONEfile &self, const std::string &lineType, int64_t dnaLen, py::bytes dnaBuf) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            std::string buf = dnaBuf;
+            self.writeLineDNA2bit(lineType[0], dnaLen, (uint8_t*)buf.data());
+        })
+
+        .def("writeComment", &ONEfile::writeComment)
+
+        // Provenance and reference methods
+        .def("addProvenance", &ONEfile::addProvenance)
+        .def("inheritProvenance", &ONEfile::inheritProvenance)
+        .def("addReference", &ONEfile::addReference)
+        .def("inheritReference", &ONEfile::inheritReference)
+
+        // Additional utility methods
+        .def("fileName", &ONEfile::fileName)
+
+        .def("count", [](ONEfile &self, const std::string &lineType) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            return self.count(lineType[0]);
+        })
+
+        .def("max", [](ONEfile &self, const std::string &lineType) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            return self.max(lineType[0]);
+        })
+
+        .def("total", [](ONEfile &self, const std::string &lineType) {
+            if (lineType.length() != 1) {
+                throw std::invalid_argument("lineType must be a single character");
+            }
+            return self.total(lineType[0]);
+        })
+
+        .def("checkSchema", &ONEfile::checkSchema);
 }
 

--- a/pyOnelib.ipynb
+++ b/pyOnelib.ipynb
@@ -1,0 +1,718 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ONEcode Python Interface Tutorial\n",
+    "\n",
+    "This notebook demonstrates the various features of the ONEcode Python bindings.\n",
+    "\n",
+    "## Installation and Setup\n",
+    "\n",
+    "First, make sure the ONEcode Python bindings are compiled:\n",
+    "\n",
+    "```bash\n",
+    "make\n",
+    "make python\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import the ONEcode Module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ONEcode module imported successfully!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ONEcode\n",
+    "print(\"ONEcode module imported successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Defining Schemas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Schema created successfully!\n",
+      "\n",
+      "Schema definition:\n",
+      "P 3 seq                 SEQUENCE\n",
+      "S 6 segseq              segment sequences - objects are 1:1 with those in seg file\n",
+      "S 7 readseq             read sequences\n",
+      "O S 1 3 DNA             sequence: the DNA string\n",
+      "D I 1 6 STRING          id - sequence identifier; unnecessary for segments\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define a schema for sequence files\n",
+    "schema_text = (\n",
+    "    \"P 3 seq                 SEQUENCE\\n\"\n",
+    "    \"S 6 segseq              segment sequences - objects are 1:1 with those in seg file\\n\"\n",
+    "    \"S 7 readseq             read sequences\\n\"\n",
+    "    \"O S 1 3 DNA             sequence: the DNA string\\n\"\n",
+    "    \"D I 1 6 STRING          id - sequence identifier; unnecessary for segments\\n\"\n",
+    ")\n",
+    "\n",
+    "schema = ONEcode.ONEschema(schema_text)\n",
+    "print(\"Schema created successfully!\")\n",
+    "print(\"\\nSchema definition:\")\n",
+    "print(schema_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Opening Files for Reading\n",
+    "\n",
+    "There are several ways to open a ONEcode file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File opened: ./TEST/small.seq\n",
+      "Number of sequences: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Simple read (1 thread)\n",
+    "onefile = ONEcode.ONEfile(\"./TEST/small.seq\")\n",
+    "print(f\"File opened: {onefile.fileName()}\")\n",
+    "print(f\"Number of sequences: {onefile.givenCount('S')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File opened with schema validation\n",
+      "Total sequences in file: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Read with schema validation\n",
+    "onefile = ONEcode.ONEfile(\"./TEST/small.seq\", \"r\", schema, \"\", 1)\n",
+    "print(f\"File opened with schema validation\")\n",
+    "print(f\"Total sequences in file: {onefile.givenCount('S')}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File opened with 4 threads for parallel decompression\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Read with multiple threads (for large binary files)\n",
+    "onefile = ONEcode.ONEfile(\"./TEST/small.seq\", 4)  # 4 threads\n",
+    "print(f\"File opened with 4 threads for parallel decompression\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Reading Data Line by Line\n",
+    "\n",
+    "The main pattern for reading ONEcode files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading sequences from ./TEST/small.seq\n",
+      "Expected 10 sequences\n",
+      "\n",
+      "Sequence 1: length=51, DNA=cttagtagcgatattagttaataaaggtaaattcaaatgcgagtggtaga...\n",
+      "  ID: seq1\n",
+      "Sequence 2: length=72, DNA=ctttaccctccgaggctcttatccaccagaaacttccgccggggtccagg...\n",
+      "  ID: seq2\n",
+      "Sequence 3: length=58, DNA=catattctgtcgtaaatgtagaagaaagtagtagacaactcagaacgatc...\n",
+      "  ID: seq3\n",
+      "Sequence 4: length=42, DNA=ttttgagcgagagagaatgataagacctcgagggagcttgaa\n",
+      "  ID: seq4\n",
+      "Sequence 5: length=55, DNA=tttaaatcaaaggccgaagtttttttaagcgacaaagcactttaatatca...\n",
+      "  ID: seq5\n",
+      "Sequence 6: length=66, DNA=agagtgaatatcattaaactagacattcacgatagaaaattagttaatta...\n",
+      "  ID: seq6\n",
+      "Sequence 7: length=47, DNA=gctctgtataatgtttctgttttactgtgtttgggattatgctaagc\n",
+      "  ID: seq7\n",
+      "Sequence 8: length=62, DNA=ccgagatctataacagtatcaaaaataaaaaacttttaataaaatattaa...\n",
+      "  ID: seq8\n",
+      "Sequence 9: length=53, DNA=tagaagttgtttaataagttttattcacaatcgtttaatatttacacata...\n",
+      "  ID: seq9\n",
+      "Sequence 10: length=71, DNA=acatttacatattgatgtaacactcctatagcctttgatgaccgaaaact...\n",
+      "  ID: seq10\n",
+      "\n",
+      "Total sequences read: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Open the file\n",
+    "onefile = ONEcode.ONEfile(\"./TEST/small.seq\", \"r\", schema, \"\", 1)\n",
+    "\n",
+    "print(f\"Reading sequences from {onefile.fileName()}\")\n",
+    "print(f\"Expected {onefile.givenCount('S')} sequences\\n\")\n",
+    "\n",
+    "seq_count = 0\n",
+    "\n",
+    "# Read through the file line by line\n",
+    "while onefile.readLine():\n",
+    "    line_type = onefile.lineType()\n",
+    "    line_num = onefile.lineNumber()\n",
+    "    \n",
+    "    if line_type == 'S':\n",
+    "        seq_count += 1\n",
+    "        sequence = onefile.getString()\n",
+    "        length = onefile.length()\n",
+    "        print(f\"Sequence {seq_count}: length={length}, DNA={sequence[:50]}...\" if length > 50 else f\"Sequence {seq_count}: length={length}, DNA={sequence}\")\n",
+    "        \n",
+    "    elif line_type == 'I':\n",
+    "        seq_id = onefile.getString()\n",
+    "        print(f\"  ID: {seq_id}\")\n",
+    "\n",
+    "print(f\"\\nTotal sequences read: {seq_count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Different Ways to Access DNA Data\n",
+    "\n",
+    "ONEcode provides multiple ways to access DNA sequences:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Different ways to access DNA data:\n",
+      "\n",
+      "1. getString(): cttagtagcgatattagttaataaaggtaaattcaaatgcgagtggtaga...\n",
+      "2. getDNAchar(): cttagtagcgatattagttaataaaggtaaattcaaatgcgagtggtaga...\n",
+      "3. getDNA2bit(): 13 bytes for 51 bases\n",
+      "   Compression ratio: 3.92x\n"
+     ]
+    }
+   ],
+   "source": [
+    "onefile = ONEcode.ONEfile(\"./TEST/small.seq\", \"r\", schema, \"\", 1)\n",
+    "\n",
+    "# Read first sequence\n",
+    "while onefile.readLine():\n",
+    "    if onefile.lineType() == 'S':\n",
+    "        print(\"Different ways to access DNA data:\\n\")\n",
+    "        \n",
+    "        # 1. As a string\n",
+    "        dna_string = onefile.getString()\n",
+    "        print(f\"1. getString(): {dna_string[:50]}...\")\n",
+    "        \n",
+    "        # 2. As character array\n",
+    "        dna_chars = onefile.getDNAchar()\n",
+    "        print(f\"2. getDNAchar(): {dna_chars[:50]}...\")\n",
+    "        \n",
+    "        # 3. As 2-bit compressed format (4 bases per byte)\n",
+    "        dna_2bit = onefile.getDNA2bit()\n",
+    "        print(f\"3. getDNA2bit(): {len(dna_2bit)} bytes for {onefile.length()} bases\")\n",
+    "        print(f\"   Compression ratio: {onefile.length() / len(dna_2bit):.2f}x\")\n",
+    "        \n",
+    "        break  # Just show first sequence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. File Metadata and Statistics\n",
+    "\n",
+    "Get information about the file contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File Statistics:\n",
+      "==================================================\n",
+      "File name: ./TEST/small.seq\n",
+      "\n",
+      "Sequence statistics:\n",
+      "  Count (S lines): 10\n",
+      "  Max length: 72\n",
+      "  Total bases: 577\n",
+      "  Average length: 57.7\n"
+     ]
+    }
+   ],
+   "source": [
+    "onefile = ONEcode.ONEfile(\"./TEST/small.seq\", \"r\", schema, \"\", 1)\n",
+    "\n",
+    "print(\"File Statistics:\")\n",
+    "print(\"=\" * 50)\n",
+    "print(f\"File name: {onefile.fileName()}\")\n",
+    "print(f\"\\nSequence statistics:\")\n",
+    "print(f\"  Count (S lines): {onefile.givenCount('S')}\")\n",
+    "print(f\"  Max length: {onefile.givenMax('S')}\")\n",
+    "print(f\"  Total bases: {onefile.givenTotal('S')}\")\n",
+    "\n",
+    "if onefile.givenCount('S') > 0:\n",
+    "    avg_length = onefile.givenTotal('S') / onefile.givenCount('S')\n",
+    "    print(f\"  Average length: {avg_length:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Writing ONEcode Files\n",
+    "\n",
+    "Create new ONEcode files in ASCII or binary format:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ASCII file created: ./TEST/example_output.seq\n",
+      "Wrote 3 sequences\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a new ASCII file\n",
+    "outfile_ascii = ONEcode.ONEfile(\"./TEST/example_output.seq\", \"w\", schema, \"seq\", 1)\n",
+    "\n",
+    "# Add provenance information\n",
+    "outfile_ascii.addProvenance(\"python_tutorial\", \"1.0.0\", \"Creating example sequences from Jupyter notebook\")\n",
+    "\n",
+    "# Write some example sequences\n",
+    "sequences = [\n",
+    "    (\"ACGTACGTACGTACGT\", \"seq1\"),\n",
+    "    (\"GGGGCCCCAAAAATTTT\", \"seq2\"),\n",
+    "    (\"ATCGATCGATCGATCG\", \"seq3\"),\n",
+    "]\n",
+    "\n",
+    "for seq, seq_id in sequences:\n",
+    "    # Write the sequence (S line)\n",
+    "    outfile_ascii.writeLine('S', seq)\n",
+    "    # Write the ID (I line)\n",
+    "    outfile_ascii.writeLine('I', seq_id)\n",
+    "\n",
+    "# Close the file (important!)\n",
+    "del outfile_ascii\n",
+    "\n",
+    "print(\"ASCII file created: ./TEST/example_output.seq\")\n",
+    "print(f\"Wrote {len(sequences)} sequences\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Binary file created: ./TEST/example_output.1seq\n",
+      "Binary files are compressed and faster to read!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create a binary file\n",
+    "outfile_binary = ONEcode.ONEfile(\"./TEST/example_output.1seq\", \"wb\", schema, \"seq\", 1)\n",
+    "\n",
+    "outfile_binary.addProvenance(\"python_tutorial\", \"1.0.0\", \"Creating binary example\")\n",
+    "\n",
+    "for seq, seq_id in sequences:\n",
+    "    outfile_binary.writeLine('S', seq)\n",
+    "    outfile_binary.writeLine('I', seq_id)\n",
+    "\n",
+    "del outfile_binary\n",
+    "\n",
+    "print(\"Binary file created: ./TEST/example_output.1seq\")\n",
+    "print(\"Binary files are compressed and faster to read!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Verify the Written Files\n",
+    "\n",
+    "Read back the files we just created:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading ASCII file:\n",
+      "  Sequence: ACGTACGTACGTACGT\n",
+      "    ID: seq1\n",
+      "  Sequence: GGGGCCCCAAAAATTTT\n",
+      "    ID: seq2\n",
+      "  Sequence: ATCGATCGATCGATCG\n",
+      "    ID: seq3\n",
+      "\n",
+      "Reading binary file:\n",
+      "  Sequence: acgtacgtacgtacgt\n",
+      "    ID: seq1\n",
+      "  Sequence: ggggccccaaaaatttt\n",
+      "    ID: seq2\n",
+      "  Sequence: atcgatcgatcgatcgt\n",
+      "    ID: seq3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Read the ASCII file\n",
+    "print(\"Reading ASCII file:\")\n",
+    "infile = ONEcode.ONEfile(\"./TEST/example_output.seq\", \"r\", schema, \"\", 1)\n",
+    "while infile.readLine():\n",
+    "    if infile.lineType() == 'S':\n",
+    "        print(f\"  Sequence: {infile.getString()}\")\n",
+    "    elif infile.lineType() == 'I':\n",
+    "        print(f\"    ID: {infile.getString()}\")\n",
+    "\n",
+    "print(\"\\nReading binary file:\")\n",
+    "infile = ONEcode.ONEfile(\"./TEST/example_output.1seq\", \"r\", schema, \"\", 1)\n",
+    "while infile.readLine():\n",
+    "    if infile.lineType() == 'S':\n",
+    "        print(f\"  Sequence: {infile.getString()}\")\n",
+    "    elif infile.lineType() == 'I':\n",
+    "        print(f\"    ID: {infile.getString()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Working with Integer and Real Lists\n",
+    "\n",
+    "ONEcode supports lists of integers and real numbers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "List demo file created!\n",
+      "\n",
+      "Reading back:\n",
+      "Data object\n",
+      "  Quality scores: 10\n",
+      "  Features: 1.5\n",
+      "  Tags: ['tag1', 'tag2', 'tag3']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define a schema with integer and real lists\n",
+    "list_schema_text = (\n",
+    "    \"P 4 demo                 DEMO FILE\\n\"\n",
+    "    \"O D 0                    data object\\n\"\n",
+    "    \"D Q 1 8 INT_LIST         quality scores\\n\"\n",
+    "    \"D F 1 9 REAL_LIST        feature values\\n\"\n",
+    "    \"D T 1 11 STRING_LIST     tags\\n\"\n",
+    ")\n",
+    "\n",
+    "list_schema = ONEcode.ONEschema(list_schema_text)\n",
+    "\n",
+    "# Write a file with lists\n",
+    "outfile = ONEcode.ONEfile(\"./TEST/list_demo.demo\", \"w\", list_schema, \"demo\", 1)\n",
+    "outfile.addProvenance(\"python_tutorial\", \"1.0.0\", \"Demo of list types\")\n",
+    "\n",
+    "# Write object marker\n",
+    "outfile.writeLine('D')\n",
+    "\n",
+    "# Write integer list (quality scores)\n",
+    "quality_scores = [10, 20, 30, 40, 35, 30, 25, 20]\n",
+    "outfile.writeLineIntList('Q', quality_scores)\n",
+    "\n",
+    "# Write real list (feature values)\n",
+    "features = [1.5, 2.7, 3.1, 4.9, 5.2]\n",
+    "outfile.writeLineRealList('F', features)\n",
+    "\n",
+    "# Write string list (tags)\n",
+    "tags = [\"tag1\", \"tag2\", \"tag3\"]\n",
+    "outfile.writeLine('T', tags)\n",
+    "\n",
+    "del outfile\n",
+    "\n",
+    "print(\"List demo file created!\")\n",
+    "\n",
+    "# Read it back\n",
+    "print(\"\\nReading back:\")\n",
+    "infile = ONEcode.ONEfile(\"./TEST/list_demo.demo\", \"r\", list_schema, \"\", 1)\n",
+    "while infile.readLine():\n",
+    "    lt = infile.lineType()\n",
+    "    if lt == 'D':\n",
+    "        print(\"Data object\")\n",
+    "    elif lt == 'Q':\n",
+    "        quals = infile.getIntList()\n",
+    "        print(f\"  Quality scores: {quals}\")\n",
+    "    elif lt == 'F':\n",
+    "        feats = infile.getRealList()\n",
+    "        print(f\"  Features: {feats}\")\n",
+    "    elif lt == 'T':\n",
+    "        tag_list = infile.getStringList()\n",
+    "        print(f\"  Tags: {tag_list}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Random Access with gotoObject\n",
+    "\n",
+    "For binary files, you can jump directly to specific objects:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This only works with binary files that have an index\n",
+    "onefile = ONEcode.ONEfile(\"./TEST/example_output.1seq\", \"r\", schema, \"\", 1)\n",
+    "\n",
+    "print(f\"Total sequences: {onefile.givenCount('S')}\\n\")\n",
+    "\n",
+    "# Jump to the 2nd sequence\n",
+    "if onefile.gotoObject('S', 2):\n",
+    "    print(\"Jumped to sequence #2:\")\n",
+    "    if onefile.readLine() and onefile.lineType() == 'S':\n",
+    "        print(f\"  Sequence: {onefile.getString()}\")\n",
+    "    if onefile.readLine() and onefile.lineType() == 'I':\n",
+    "        print(f\"  ID: {onefile.getString()}\")\n",
+    "else:\n",
+    "    print(\"Could not jump to object (may need a larger file or different format)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Schema Validation\n",
+    "\n",
+    "Check if a file matches an expected schema:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "onefile = ONEcode.ONEfile(\"./TEST/small.seq\", \"r\", schema, \"\", 1)\n",
+    "\n",
+    "# Check against schema text\n",
+    "schema_check = (\n",
+    "    \"P 3 seq\\n\"\n",
+    "    \"O S 1 3 DNA\\n\"\n",
+    "    \"D I 1 6 STRING\\n\"\n",
+    ")\n",
+    "\n",
+    "if onefile.checkSchemaText(schema_check):\n",
+    "    print(\"✓ File matches the expected schema!\")\n",
+    "else:\n",
+    "    print(\"✗ Schema mismatch\")\n",
+    "\n",
+    "# Try with a wrong schema\n",
+    "wrong_schema = (\n",
+    "    \"P 3 seq\\n\"\n",
+    "    \"O S 1 3 INT\\n\"  # Wrong: S should be DNA, not INT\n",
+    ")\n",
+    "\n",
+    "if onefile.checkSchemaText(wrong_schema):\n",
+    "    print(\"✓ File matches wrong schema (unexpected!)\")\n",
+    "else:\n",
+    "    print(\"✗ File correctly rejected wrong schema\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 11. Practical Example: Reverse Complement\n",
+    "\n",
+    "Read sequences and write their reverse complements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Processing sequences...\n",
+      "\n",
+      "Sequence 1:\n",
+      "  Original: cttagtagcgatattagttaataaaggtaaattcaaatgc...\n",
+      "  Rev-comp: atctaccactcgcatttgaatttacctttattaactaata...\n",
+      "Sequence 2:\n",
+      "  Original: ctttaccctccgaggctcttatccaccagaaacttccgcc...\n",
+      "  Rev-comp: attacagaagaacgttaagagtcctggaccccggcggaag...\n",
+      "Sequence 3:\n",
+      "  Original: catattctgtcgtaaatgtagaagaaagtagtagacaact...\n",
+      "  Rev-comp: accgttctgatcgttctgagttgtctactactttcttcta...\n",
+      "\n",
+      "✓ Processed 10 sequences\n",
+      "✓ Output written to: ./TEST/small_rc.1seq\n"
+     ]
+    }
+   ],
+   "source": [
+    "def reverse_complement(seq):\n",
+    "    \"\"\"Simple reverse complement for DNA sequences\"\"\"\n",
+    "    complement = {'A': 'T', 'T': 'A', 'G': 'C', 'C': 'G',\n",
+    "                  'a': 't', 't': 'a', 'g': 'c', 'c': 'g'}\n",
+    "    return ''.join(complement.get(base, base) for base in reversed(seq))\n",
+    "\n",
+    "# Open input file\n",
+    "infile = ONEcode.ONEfile(\"./TEST/small.seq\", \"r\", schema, \"\", 1)\n",
+    "\n",
+    "# Create output file for reverse complements\n",
+    "outfile = ONEcode.ONEfile(\"./TEST/small_rc.1seq\", \"wb\", schema, \"seq\", 1)\n",
+    "outfile.addProvenance(\"python_tutorial\", \"1.0.0\", \"Reverse complement from Python\")\n",
+    "\n",
+    "seq_count = 0\n",
+    "\n",
+    "# Process sequences\n",
+    "print(\"Processing sequences...\\n\")\n",
+    "while infile.readLine():\n",
+    "    lt = infile.lineType()\n",
+    "    \n",
+    "    if lt == 'S':\n",
+    "        seq = infile.getString()\n",
+    "        rc_seq = reverse_complement(seq)\n",
+    "        outfile.writeLine('S', rc_seq)\n",
+    "        seq_count += 1\n",
+    "        \n",
+    "        # Show first few\n",
+    "        if seq_count <= 3:\n",
+    "            print(f\"Sequence {seq_count}:\")\n",
+    "            print(f\"  Original: {seq[:40]}...\" if len(seq) > 40 else f\"  Original: {seq}\")\n",
+    "            print(f\"  Rev-comp: {rc_seq[:40]}...\" if len(rc_seq) > 40 else f\"  Rev-comp: {rc_seq}\")\n",
+    "    \n",
+    "    elif lt == 'I':\n",
+    "        seq_id = infile.getString()\n",
+    "        outfile.writeLine('I', seq_id + \"_RC\")\n",
+    "\n",
+    "del outfile\n",
+    "\n",
+    "print(f\"\\n✓ Processed {seq_count} sequences\")\n",
+    "print(f\"✓ Output written to: ./TEST/small_rc.1seq\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Uses pybind to create a python interface for ONEcode files, wrapping around existing functionality in the C++ interface (ONElib.hpp). 

Notebook provides example usage patterns e.g. see https://github.com/AnantMaheshwari/ONEcode/blob/python_API/pyOnelib.ipynb
for examples of interacting with the API.

For example, the below code block would allow a user to read sequences from a test file (TEST/small.1seq) and write a new ONEfile that is the same sequences reverse complemented (TEST/small_rc.1seq)

```python

def reverse_complement(seq):
    """Simple reverse complement for DNA sequences"""
    complement = {'A': 'T', 'T': 'A', 'G': 'C', 'C': 'G',
                  'a': 't', 't': 'a', 'g': 'c', 'c': 'g'}
    return ''.join(complement.get(base, base) for base in reversed(seq))

# Open input file
infile = ONEcode.ONEfile("./TEST/small.seq", "r", schema, "", 1)

# Create output file for reverse complements
outfile = ONEcode.ONEfile("./TEST/small_rc.1seq", "wb", schema, "seq", 1)
outfile.addProvenance("python_tutorial", "1.0.0", "Reverse complement from Python")

# Process sequences
print("Processing sequences...\n")
while infile.readLine():
    lt = infile.lineType()
    
    if lt == 'S':
        seq = infile.getString()
        rc_seq = reverse_complement(seq)
        outfile.writeLine('S', rc_seq)
        
            print(f"Sequence {seq_count}:")
            print(f"  Original: {seq[:40]}..." if len(seq) > 40 else f"  Original: {seq}")
            print(f"  Rev-comp: {rc_seq[:40]}..." if len(rc_seq) > 40 else f"  Rev-comp: {rc_seq}")
    
    elif lt == 'I':
        seq_id = infile.getString()
        outfile.writeLine('I', seq_id + "_RC")

del outfile

print(f"Output written to: ./TEST/small_rc.1seq")

